### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ git clone https://github.com/PureStorage-OpenConnect/TestDriveNewStack
 
 Run the setup.sh script by typing the following:
 ```
-~/TestDriveNewStack/setup.sh
+cd ./TestDriveNewStack
+./setup.sh
 ```
 
 ## Try out Ansible


### PR DESCRIPTION
If you run the setup script when you are not actually in the TestDriveNewStack directory, the scripts that ask to install Kubernetes fail to load.